### PR TITLE
Add support for single-date selection behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A simple, stylish `DateTimeRange` picker component for Flutter.
 
+**Note:** This package is under active development and may change significantly between versions. Once a stable implementation is reached, the package will be bumped to version 1.0.0.
+
 ## Features
 
 * In-line widget for selecting a range of dates (`DateTimeRange`)

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -36,6 +36,20 @@ class _DemoPageState extends State<DemoPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      appBar: AppBar(
+        actions: [
+          ElevatedButton(
+            child: const Text('showSimpleDateRangePickerDialog'),
+            onPressed: () async {
+              final newDates = await showSimpleDateRangePickerDialog(context);
+
+              if (newDates != null) {
+                setState(() => selectedDateRange = newDates);
+              }
+            },
+          ),
+        ],
+      ),
       body: SizedBox(
         width: double.infinity,
         child: Padding(

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -31,130 +31,106 @@ class DemoPage extends StatefulWidget {
 
 class _DemoPageState extends State<DemoPage> {
   DateTimeRange? selectedDateRange;
+  DateTime? selectedDate;
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       body: SizedBox(
         width: double.infinity,
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.center,
-          mainAxisAlignment: MainAxisAlignment.center,
-          mainAxisSize: MainAxisSize.max,
-          children: [
-            if (selectedDateRange == null) ...[
-              const Text('No date range selected'),
-            ] else ...[
-              Text(
-                'Selected Date Range: ${DateFormat.yMMMd().format(selectedDateRange!.start)} - ${DateFormat.yMMMd().format(selectedDateRange!.end)}',
+        child: Padding(
+          padding: const EdgeInsets.all(8.0),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Expanded(
+                child: Row(
+                  children: [
+                    Expanded(
+                      child: SingleChildScrollView(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.center,
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            const Text(
+                              'In-line date range picker',
+                              style: TextStyle(
+                                fontSize: 22,
+                                fontWeight: FontWeight.bold,
+                              ),
+                            ),
+                            const SizedBox(height: 25),
+                            if (selectedDateRange == null) ...[
+                              const Text('No date range selected'),
+                            ] else ...[
+                              Text(
+                                'Selected Date Range: ${DateFormat.yMMMd().format(selectedDateRange!.start)} - ${DateFormat.yMMMd().format(selectedDateRange!.end)}',
+                              ),
+                            ],
+                            const SizedBox(height: 50),
+                            SimpleDateRangePicker(
+                              config: SimpleDateRangePickerRange(
+                                initialDateRange: null,
+                                onChanged: (dates) => setState(
+                                  () => selectedDateRange = dates,
+                                ),
+                              ),
+                              style: const SimpleDateRangePickerStyle(
+                                colors: SimpleDateRangePickerColors(
+                                  backgroundColor: Colors.pink,
+                                  foregroundColor: Colors.white,
+                                ),
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                    Expanded(
+                      child: SingleChildScrollView(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.center,
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            const Text(
+                              'In-line single date picker',
+                              style: TextStyle(
+                                fontSize: 22,
+                                fontWeight: FontWeight.bold,
+                              ),
+                            ),
+                            const SizedBox(height: 25),
+                            if (selectedDate == null) ...[
+                              const Text('No single date selected'),
+                            ] else ...[
+                              Text(
+                                'Selected Date: ${DateFormat.yMMMd().format(selectedDate!)}}',
+                              ),
+                            ],
+                            const SizedBox(height: 50),
+                            SimpleDateRangePicker(
+                              config: SimpleDateRangePickerSingle(
+                                initialDate: null,
+                                onChanged: (date) => setState(
+                                  () => selectedDate = date,
+                                ),
+                              ),
+                              style: const SimpleDateRangePickerStyle(
+                                colors: SimpleDateRangePickerColors(
+                                  backgroundColor: Colors.pink,
+                                  foregroundColor: Colors.white,
+                                ),
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
               ),
             ],
-            const SizedBox(height: 50),
-            const Text('In-line date range picker'),
-            const SizedBox(height: 25),
-            Flexible(
-              child: SimpleDateRangePicker(
-                config: SimpleDateRangePickerRange(
-                  initialDateRange: null,
-                  onChanged: (dates) => setState(
-                    () => selectedDateRange = dates,
-                  ),
-                ),
-                style: const SimpleDateRangePickerStyle(
-                  colors: SimpleDateRangePickerColors(
-                    backgroundColor: Colors.pink,
-                    foregroundColor: Colors.white,
-                  ),
-                ),
-              ),
-            ),
-            const SizedBox(height: 25),
-            ElevatedButton(
-              onPressed: () async {
-                final dates = await showSimpleDateRangePickerDialog(context);
-
-                if (dates != null) {
-                  setState(() => selectedDateRange = dates);
-                }
-              },
-              child: const Text('showSimpleDateRangePickerDialog'),
-            ),
-            const SizedBox(height: 25),
-            ElevatedButton(
-              onPressed: () async {
-                final dates = await showSimpleDateRangePickerDialog(
-                  context,
-                  backgroundColor: Colors.green,
-                  shape: const RoundedRectangleBorder(
-                    borderRadius: BorderRadius.zero,
-                  ),
-                  cancelButtonStyle: ButtonStyle(
-                    shape: MaterialStateProperty.all(
-                      const RoundedRectangleBorder(
-                        borderRadius: BorderRadius.all(Radius.circular(0)),
-                      ),
-                    ),
-                    backgroundColor: MaterialStatePropertyAll(
-                      Colors.red.shade500,
-                    ),
-                    foregroundColor: const MaterialStatePropertyAll(
-                      Colors.white,
-                    ),
-                  ),
-                  confirmButtonStyle: ButtonStyle(
-                    shape: MaterialStateProperty.all(
-                      const RoundedRectangleBorder(
-                        borderRadius: BorderRadius.all(Radius.circular(0)),
-                      ),
-                    ),
-                    backgroundColor: const MaterialStatePropertyAll(
-                      Colors.black12,
-                    ),
-                    foregroundColor: const MaterialStatePropertyAll(
-                      Colors.white,
-                    ),
-                  ),
-                  style: SimpleDateRangePickerStyle(
-                    colors: const SimpleDateRangePickerColors(
-                      backgroundColor: Colors.amber,
-                      foregroundColor: Colors.black,
-                      boundaryOpacity: 0.8,
-                      hoveredOpacity: 0.9,
-                      selectedOpacity: 0.5,
-                    ),
-                    monthTitleTextStyle: Theme.of(context).textTheme.titleLarge,
-                    weekdayTextStyle: const TextStyle(
-                      fontWeight: FontWeight.bold,
-                      fontSize: 20,
-                    ),
-                    dayTextStyle: const TextStyle(
-                      fontSize: 18,
-                    ),
-                    activeItemRadius: Radius.zero,
-                    previousIconButtonStyle: ButtonStyle(
-                      shape: MaterialStateProperty.all(
-                        const RoundedRectangleBorder(),
-                      ),
-                    ),
-                    nextIconButtonStyle: ButtonStyle(
-                      shape: MaterialStateProperty.all(
-                        const RoundedRectangleBorder(),
-                      ),
-                    ),
-                  ),
-                  cancelLabel: 'Discard',
-                  confirmLabel: 'Save',
-                );
-
-                if (dates != null) {
-                  setState(() => selectedDateRange = dates);
-                }
-              },
-              child: const Text(
-                'showSimpleDateRangePickerDialog (Custom)',
-              ),
-            ),
-          ],
+          ),
         ),
       ),
     );

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -54,7 +54,12 @@ class _DemoPageState extends State<DemoPage> {
             const SizedBox(height: 25),
             Flexible(
               child: SimpleDateRangePicker(
-                onChanged: (dates) => setState(() => selectedDateRange = dates),
+                config: SimpleDateRangePickerRange(
+                  initialDateRange: null,
+                  onChanged: (dates) => setState(
+                    () => selectedDateRange = dates,
+                  ),
+                ),
                 style: const SimpleDateRangePickerStyle(
                   colors: SimpleDateRangePickerColors(
                     backgroundColor: Colors.pink,

--- a/lib/simple_date_range_picker.dart
+++ b/lib/simple_date_range_picker.dart
@@ -1,5 +1,6 @@
 library simple_date_range_picker;
 
+export 'package:simple_date_range_picker/src/models/simple_date_range_picker_config.dart';
 export 'package:simple_date_range_picker/src/widgets/simple_date_range_picker.dart';
 export 'package:simple_date_range_picker/src/show_simple_date_range_picker_dialog.dart';
 export 'package:simple_date_range_picker/src/style/style.dart';

--- a/lib/src/date_selection_type.dart
+++ b/lib/src/date_selection_type.dart
@@ -1,4 +1,4 @@
-enum SelectionType {
+enum DateSelectionType {
   none,
   start,
   middle,

--- a/lib/src/models/simple_date_range_picker_config.dart
+++ b/lib/src/models/simple_date_range_picker_config.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+
+sealed class SimpleDateRangePickerConfig {
+  const SimpleDateRangePickerConfig();
+
+  List<DateTime> get dates;
+}
+
+class SimpleDateRangePickerRange extends SimpleDateRangePickerConfig {
+  const SimpleDateRangePickerRange({
+    required this.initialDateRange,
+    required this.onChanged,
+  });
+
+  final DateTimeRange? initialDateRange;
+  final ValueChanged<DateTimeRange?> onChanged;
+
+  @override
+  List<DateTime> get dates {
+    if (initialDateRange == null) {
+      return const [];
+    }
+
+    var dates = <DateTime>[];
+    var date = initialDateRange!.start;
+
+    while (date.isBefore(initialDateRange!.end)) {
+      dates.add(date);
+      date = date.add(const Duration(days: 1));
+    }
+
+    dates.add(initialDateRange!.end);
+    return dates;
+  }
+
+  SimpleDateRangePickerRange copyWith({
+    DateTimeRange? dateRange,
+  }) {
+    return SimpleDateRangePickerRange(
+      initialDateRange: dateRange,
+      onChanged: onChanged,
+    );
+  }
+}

--- a/lib/src/models/simple_date_range_picker_config.dart
+++ b/lib/src/models/simple_date_range_picker_config.dart
@@ -4,41 +4,83 @@ sealed class SimpleDateRangePickerConfig {
   const SimpleDateRangePickerConfig();
 
   List<DateTime> get dates;
+  void onSelected(DateTime date);
 }
 
 class SimpleDateRangePickerRange extends SimpleDateRangePickerConfig {
-  const SimpleDateRangePickerRange({
+  SimpleDateRangePickerRange({
     required this.initialDateRange,
     required this.onChanged,
-  });
+  })  : _startDate = initialDateRange?.start,
+        _endDate = initialDateRange?.end;
 
   final DateTimeRange? initialDateRange;
   final ValueChanged<DateTimeRange?> onChanged;
+  DateTime? _startDate;
+  DateTime? _endDate;
+
+  @override
+  void onSelected(DateTime date) {
+    // selecting the start date again resets the selection
+    if (date == _startDate) {
+      _startDate = null;
+      // selecting the end date again resets the selection
+    } else if (date == _endDate) {
+      _endDate = null;
+      // selecting a new date when both ends of the range have been selected
+      // resets the selection with the new date as the start date
+    } else if (_startDate != null && _endDate != null) {
+      _endDate = null;
+      _startDate = date;
+      // selecting a date that lies after the end date moves the start date
+      // to the current end date and sets the end date to the newly selected
+      // date
+    } else if (_endDate != null && date.isAfter(_endDate!)) {
+      _startDate = _endDate;
+      _endDate = date;
+      // selecting a date that lies before the current start date sets it as
+      // the new start date
+    } else if (_startDate != null && date.isBefore(_startDate!)) {
+      _startDate = date;
+      // if no end date has been selected, the new date becomes the end date
+    } else if (_startDate != null && _endDate == null) {
+      _endDate = date;
+      // if all other conditions are false, this newly selected date is the
+      // beginning of a new date range
+    } else {
+      _startDate = date;
+    }
+
+    if (_startDate == null || _endDate == null) {
+      onChanged(null);
+    } else {
+      onChanged(DateTimeRange(start: _startDate!, end: _endDate!));
+    }
+  }
 
   @override
   List<DateTime> get dates {
-    if (initialDateRange == null) {
+    if (_startDate == null && _endDate == null) {
       return const [];
     }
 
-    var dates = <DateTime>[];
-    var date = initialDateRange!.start;
+    if (_endDate == null) {
+      return [_startDate!];
+    }
 
-    while (date.isBefore(initialDateRange!.end)) {
+    if (_startDate == null) {
+      return [_endDate!];
+    }
+
+    var dates = <DateTime>[];
+    var date = _startDate!;
+
+    while (date.isBefore(_endDate!)) {
       dates.add(date);
       date = date.add(const Duration(days: 1));
     }
 
-    dates.add(initialDateRange!.end);
+    dates.add(_endDate!);
     return dates;
-  }
-
-  SimpleDateRangePickerRange copyWith({
-    DateTimeRange? dateRange,
-  }) {
-    return SimpleDateRangePickerRange(
-      initialDateRange: dateRange,
-      onChanged: onChanged,
-    );
   }
 }

--- a/lib/src/models/simple_date_range_picker_config.dart
+++ b/lib/src/models/simple_date_range_picker_config.dart
@@ -84,3 +84,34 @@ class SimpleDateRangePickerRange extends SimpleDateRangePickerConfig {
     return dates;
   }
 }
+
+class SimpleDateRangePickerSingle extends SimpleDateRangePickerConfig {
+  SimpleDateRangePickerSingle({
+    required this.initialDate,
+    required this.onChanged,
+  }) : _selectedDate = initialDate;
+
+  final DateTime? initialDate;
+  final ValueChanged<DateTime?> onChanged;
+  DateTime? _selectedDate;
+
+  @override
+  List<DateTime> get dates {
+    if (_selectedDate == null) {
+      return const [];
+    }
+
+    return [_selectedDate!];
+  }
+
+  @override
+  void onSelected(DateTime date) {
+    if (date == _selectedDate) {
+      _selectedDate = null;
+    } else {
+      _selectedDate = date;
+    }
+
+    onChanged(_selectedDate);
+  }
+}

--- a/lib/src/show_simple_date_range_picker_dialog.dart
+++ b/lib/src/show_simple_date_range_picker_dialog.dart
@@ -4,6 +4,7 @@ import 'package:simple_date_range_picker/src/constants/constants.dart';
 
 Future<DateTimeRange?> showSimpleDateRangePickerDialog(
   BuildContext context, {
+  DateTimeRange? initialDateRange,
   SimpleDateRangePickerStyle? style,
   Color? backgroundColor,
   ShapeBorder? shape,
@@ -29,7 +30,10 @@ Future<DateTimeRange?> showSimpleDateRangePickerDialog(
               mainAxisSize: MainAxisSize.min,
               children: [
                 SimpleDateRangePicker(
-                  onChanged: (dates) => dateRange = dates,
+                  config: SimpleDateRangePickerRange(
+                    onChanged: (dates) => dateRange = dates,
+                    initialDateRange: initialDateRange,
+                  ),
                   style: style,
                 ),
                 const SizedBox(height: 25),

--- a/lib/src/style/simple_date_range_picker_colors.dart
+++ b/lib/src/style/simple_date_range_picker_colors.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 
 class SimpleDateRangePickerColors {
-  static const _boundaryOpacity = 0.3;
-  static const _hoveredOpacity = 0.4;
-  static const _selectedOpacity = 0.2;
+  static const _boundaryOpacity = 0.65;
+  static const _hoveredOpacity = 0.8;
+  static const _selectedOpacity = 0.5;
 
   const SimpleDateRangePickerColors({
     required this.backgroundColor,

--- a/lib/src/widgets/date_item.dart
+++ b/lib/src/widgets/date_item.dart
@@ -78,6 +78,10 @@ class _DateItemState extends State<DateItem> {
   TextStyle _getTextStyle() {
     final baseStyle = widget.style?.dayTextStyle ?? const TextStyle();
 
+    if (hovered) {
+      return baseStyle.copyWith(color: colors.foregroundColor);
+    }
+
     return switch (widget.type) {
       DateSelectionType.none => baseStyle,
       _ => baseStyle.copyWith(color: colors.foregroundColor),

--- a/lib/src/widgets/date_item.dart
+++ b/lib/src/widgets/date_item.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:simple_date_range_picker/simple_date_range_picker.dart';
 import 'package:simple_date_range_picker/src/constants/constants.dart';
-import 'package:simple_date_range_picker/src/selection_type.dart';
+import 'package:simple_date_range_picker/src/date_selection_type.dart';
 
 class DateItem extends StatefulWidget {
   const DateItem({
@@ -15,7 +15,7 @@ class DateItem extends StatefulWidget {
 
   final DateTime date;
   final bool selected;
-  final SelectionType type;
+  final DateSelectionType type;
   final VoidCallback onSelected;
   final SimpleDateRangePickerStyle? style;
 
@@ -68,10 +68,10 @@ class _DateItemState extends State<DateItem> {
 
   Color? _getBackgroundColor() {
     return colors.getBackgroundColor(
-      isSelected: widget.type != SelectionType.none,
+      isSelected: widget.type != DateSelectionType.none,
       isHovered: hovered,
-      isStartOrEndDate: widget.type == SelectionType.start ||
-          widget.type == SelectionType.end,
+      isStartOrEndDate: widget.type == DateSelectionType.start ||
+          widget.type == DateSelectionType.end,
     );
   }
 
@@ -79,7 +79,7 @@ class _DateItemState extends State<DateItem> {
     final baseStyle = widget.style?.dayTextStyle ?? const TextStyle();
 
     return switch (widget.type) {
-      SelectionType.none => baseStyle,
+      DateSelectionType.none => baseStyle,
       _ => baseStyle.copyWith(color: colors.foregroundColor),
     };
   }
@@ -90,11 +90,11 @@ class _DateItemState extends State<DateItem> {
     }
 
     return switch (widget.type) {
-      SelectionType.none => Radius.zero,
-      SelectionType.end => radius,
-      SelectionType.middle => Radius.zero,
-      SelectionType.single => radius,
-      SelectionType.start => Radius.zero,
+      DateSelectionType.none => Radius.zero,
+      DateSelectionType.end => radius,
+      DateSelectionType.middle => Radius.zero,
+      DateSelectionType.single => radius,
+      DateSelectionType.start => Radius.zero,
     };
   }
 
@@ -104,11 +104,11 @@ class _DateItemState extends State<DateItem> {
     }
 
     return switch (widget.type) {
-      SelectionType.none => Radius.zero,
-      SelectionType.end => Radius.zero,
-      SelectionType.middle => Radius.zero,
-      SelectionType.single => radius,
-      SelectionType.start => radius,
+      DateSelectionType.none => Radius.zero,
+      DateSelectionType.end => Radius.zero,
+      DateSelectionType.middle => Radius.zero,
+      DateSelectionType.single => radius,
+      DateSelectionType.start => radius,
     };
   }
 }

--- a/lib/src/widgets/month_grid.dart
+++ b/lib/src/widgets/month_grid.dart
@@ -3,7 +3,7 @@ import 'dart:math';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:simple_date_range_picker/src/constants/constants.dart';
-import 'package:simple_date_range_picker/src/selection_type.dart';
+import 'package:simple_date_range_picker/src/date_selection_type.dart';
 import 'package:simple_date_range_picker/src/widgets/date_item.dart';
 import 'package:simple_date_range_picker/src/style/simple_date_range_picker_style.dart';
 
@@ -95,23 +95,23 @@ class MonthGrid extends StatelessWidget {
     return date;
   }
 
-  SelectionType _getSelectionType(DateTime date) {
+  DateSelectionType _getSelectionType(DateTime date) {
     if (!selectedDates.contains(date)) {
-      return SelectionType.none;
+      return DateSelectionType.none;
     }
 
     if (selectedDates.length == 1 && selectedDates.first == date) {
-      return SelectionType.single;
+      return DateSelectionType.single;
     }
 
     if (selectedDates.isNotEmpty && selectedDates.first == date) {
-      return SelectionType.start;
+      return DateSelectionType.start;
     }
 
     if (selectedDates.isNotEmpty && selectedDates.last == date) {
-      return SelectionType.end;
+      return DateSelectionType.end;
     }
 
-    return SelectionType.middle;
+    return DateSelectionType.middle;
   }
 }

--- a/lib/src/widgets/month_grid.dart
+++ b/lib/src/widgets/month_grid.dart
@@ -118,7 +118,7 @@ class MonthGrid extends StatelessWidget {
 
           return DateSelectionType.middle;
         }(),
-      SimpleDateRangePickerSingle() => DateSelectionType.start,
+      SimpleDateRangePickerSingle() => DateSelectionType.single,
     };
   }
 }

--- a/lib/src/widgets/month_grid.dart
+++ b/lib/src/widgets/month_grid.dart
@@ -2,10 +2,10 @@ import 'dart:math';
 
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
+import 'package:simple_date_range_picker/simple_date_range_picker.dart';
 import 'package:simple_date_range_picker/src/constants/constants.dart';
 import 'package:simple_date_range_picker/src/date_selection_type.dart';
 import 'package:simple_date_range_picker/src/widgets/date_item.dart';
-import 'package:simple_date_range_picker/src/style/simple_date_range_picker_style.dart';
 
 class MonthGrid extends StatelessWidget {
   const MonthGrid({
@@ -13,6 +13,7 @@ class MonthGrid extends StatelessWidget {
     required this.month,
     required this.selectedDates,
     required this.onSelected,
+    required this.config,
     this.maxWidth = Constants.width,
     this.style,
   });
@@ -22,6 +23,7 @@ class MonthGrid extends StatelessWidget {
   final ValueChanged<DateTime> onSelected;
   final double maxWidth;
   final SimpleDateRangePickerStyle? style;
+  final SimpleDateRangePickerConfig config;
 
   @override
   Widget build(BuildContext context) {
@@ -100,18 +102,23 @@ class MonthGrid extends StatelessWidget {
       return DateSelectionType.none;
     }
 
-    if (selectedDates.length == 1 && selectedDates.first == date) {
-      return DateSelectionType.single;
-    }
+    return switch (config) {
+      SimpleDateRangePickerRange() => () {
+          if (selectedDates.length == 1 && selectedDates.first == date) {
+            return DateSelectionType.single;
+          }
 
-    if (selectedDates.isNotEmpty && selectedDates.first == date) {
-      return DateSelectionType.start;
-    }
+          if (selectedDates.isNotEmpty && selectedDates.first == date) {
+            return DateSelectionType.start;
+          }
 
-    if (selectedDates.isNotEmpty && selectedDates.last == date) {
-      return DateSelectionType.end;
-    }
+          if (selectedDates.isNotEmpty && selectedDates.last == date) {
+            return DateSelectionType.end;
+          }
 
-    return DateSelectionType.middle;
+          return DateSelectionType.middle;
+        }(),
+      SimpleDateRangePickerSingle() => DateSelectionType.start,
+    };
   }
 }

--- a/lib/src/widgets/simple_date_range_picker.dart
+++ b/lib/src/widgets/simple_date_range_picker.dart
@@ -8,41 +8,45 @@ import 'package:simple_date_range_picker/src/widgets/month_title.dart';
 class SimpleDateRangePicker extends StatefulWidget {
   const SimpleDateRangePicker({
     super.key,
-    required this.onChanged,
-    this.initialDateRange,
+    required this.config,
     this.width = Constants.width,
     this.style,
   });
 
-  final DateTimeRange? initialDateRange;
-  final ValueChanged<DateTimeRange?> onChanged;
   final double width;
   final SimpleDateRangePickerStyle? style;
+  final SimpleDateRangePickerConfig config;
 
   @override
   State<SimpleDateRangePicker> createState() => _SimpleDateRangePickerState();
 }
 
 class _SimpleDateRangePickerState extends State<SimpleDateRangePicker> {
-  late List<DateTime> _selectedDates;
+  late SimpleDateRangePickerConfig _selection = widget.config;
   late DateTime currentMonth;
   DateTime? startDate;
   DateTime? endDate;
 
-  List<DateTime> get selectedDates {
-    return _selectedDates;
+  List<DateTime> get selection {
+    return _selection.dates;
   }
 
-  set selectedDates(List<DateTime> value) {
-    _selectedDates = value;
+  set selection(List<DateTime> value) {
+    switch (widget.config) {
+      case SimpleDateRangePickerRange(:final onChanged):
+        final dateRange = value.isEmpty
+            ? null
+            : DateTimeRange(
+                start: value.first,
+                end: value.last,
+              );
 
-    if (_selectedDates.isEmpty) {
-      widget.onChanged(null);
-    } else {
-      widget.onChanged(DateTimeRange(
-        start: _selectedDates.first,
-        end: _selectedDates.last,
-      ));
+        _selection = SimpleDateRangePickerRange(
+          initialDateRange: dateRange,
+          onChanged: onChanged,
+        );
+
+        onChanged(dateRange);
     }
   }
 
@@ -50,24 +54,25 @@ class _SimpleDateRangePickerState extends State<SimpleDateRangePicker> {
   void initState() {
     super.initState();
 
-    if (widget.initialDateRange != null) {
-      _selectedDates = _getDateRange(
-        start: widget.initialDateRange!.start,
-        end: widget.initialDateRange!.end,
-      );
+    return switch (widget.config) {
+      SimpleDateRangePickerRange(initialDateRange: final dateRange) => () {
+          if (dateRange != null) {
+            // _selection = dateRange;
 
-      currentMonth = DateTime(
-        widget.initialDateRange!.start.year,
-        widget.initialDateRange!.start.month,
-        1,
-      );
+            currentMonth = DateTime(
+              dateRange.start.year,
+              dateRange.start.month,
+              1,
+            );
 
-      startDate = widget.initialDateRange!.start;
-      endDate = widget.initialDateRange!.end;
-    } else {
-      _selectedDates = const [];
-      currentMonth = DateTime.now();
-    }
+            startDate = dateRange.start;
+            endDate = dateRange.end;
+          } else {
+            // selection = const [];
+            currentMonth = DateTime.now();
+          }
+        }(),
+    };
   }
 
   @override
@@ -102,7 +107,7 @@ class _SimpleDateRangePickerState extends State<SimpleDateRangePicker> {
           maxWidth: widget.width,
           month: currentMonth,
           selectedDates: {
-            ...selectedDates,
+            ...selection,
             if (startDate != null) startDate!,
             if (endDate != null) endDate!,
           }.toList(),
@@ -134,28 +139,46 @@ class _SimpleDateRangePickerState extends State<SimpleDateRangePicker> {
   }
 
   void _onSelected(DateTime date) {
-    if (date == startDate) {
-      startDate = null;
-    } else if (date == endDate) {
-      endDate = null;
-    } else if (startDate != null && endDate != null) {
-      endDate = null;
-      startDate = date;
-    } else if (endDate != null && date.isAfter(endDate!)) {
-      startDate = endDate;
-      endDate = date;
-    } else if (startDate != null && date.isBefore(startDate!)) {
-      startDate = date;
-    } else if (startDate != null && endDate == null) {
-      endDate = date;
-    } else {
-      startDate = date;
-    }
+    switch (widget.config) {
+      case SimpleDateRangePickerRange():
+        // selecting the start date again resets the selection
+        if (date == startDate) {
+          startDate = null;
+          // selecting the end date again resets the selection
+        } else if (date == endDate) {
+          endDate = null;
+          // selecting a new date when both ends of the range have been selected
+          // resets the selection with the new date as the start date
+        } else if (startDate != null && endDate != null) {
+          endDate = null;
+          startDate = date;
+          // selecting a date that lies after the end date moves the start date
+          // to the current end date and sets the end date to the newly selected
+          // date
+        } else if (endDate != null && date.isAfter(endDate!)) {
+          startDate = endDate;
+          endDate = date;
+          // selecting a date that lies before the current start date sets it as
+          // the new start date
+        } else if (startDate != null && date.isBefore(startDate!)) {
+          startDate = date;
+          // if no end date has been selected, the new date becomes the end date
+        } else if (startDate != null && endDate == null) {
+          endDate = date;
+          // if all other conditions are false, this newly selected date is the
+          // beginning of a new date range
+        } else {
+          startDate = date;
+        }
 
-    if (startDate != null && endDate != null) {
-      selectedDates = _getDateRange(start: startDate!, end: endDate!);
-    } else if (selectedDates.isNotEmpty) {
-      selectedDates = const [];
+        // after the selection has been made, if there is a selected start and
+        // end date, create the full range of dates
+        if (startDate != null && endDate != null) {
+          selection = _getDateRange(start: startDate!, end: endDate!);
+          // if there is only a start date, empty the range of dates
+        } else if (selection.isNotEmpty) {
+          selection = const [];
+        }
     }
 
     setState(() {});

--- a/lib/src/widgets/simple_date_range_picker.dart
+++ b/lib/src/widgets/simple_date_range_picker.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:simple_date_range_picker/simple_date_range_picker.dart';
 import 'package:simple_date_range_picker/src/constants/constants.dart';
-import 'package:simple_date_range_picker/src/extensions/date_time_extensions.dart';
 import 'package:simple_date_range_picker/src/widgets/month_grid.dart';
 import 'package:simple_date_range_picker/src/widgets/month_title.dart';
 
@@ -22,53 +21,22 @@ class SimpleDateRangePicker extends StatefulWidget {
 }
 
 class _SimpleDateRangePickerState extends State<SimpleDateRangePicker> {
-  late SimpleDateRangePickerConfig _selection = widget.config;
+  late final config = widget.config;
   late DateTime currentMonth;
-  DateTime? startDate;
-  DateTime? endDate;
-
-  List<DateTime> get selection {
-    return _selection.dates;
-  }
-
-  set selection(List<DateTime> value) {
-    switch (widget.config) {
-      case SimpleDateRangePickerRange(:final onChanged):
-        final dateRange = value.isEmpty
-            ? null
-            : DateTimeRange(
-                start: value.first,
-                end: value.last,
-              );
-
-        _selection = SimpleDateRangePickerRange(
-          initialDateRange: dateRange,
-          onChanged: onChanged,
-        );
-
-        onChanged(dateRange);
-    }
-  }
 
   @override
   void initState() {
     super.initState();
 
-    return switch (widget.config) {
+    return switch (config) {
       SimpleDateRangePickerRange(initialDateRange: final dateRange) => () {
           if (dateRange != null) {
-            // _selection = dateRange;
-
             currentMonth = DateTime(
               dateRange.start.year,
               dateRange.start.month,
               1,
             );
-
-            startDate = dateRange.start;
-            endDate = dateRange.end;
           } else {
-            // selection = const [];
             currentMonth = DateTime.now();
           }
         }(),
@@ -107,9 +75,7 @@ class _SimpleDateRangePickerState extends State<SimpleDateRangePicker> {
           maxWidth: widget.width,
           month: currentMonth,
           selectedDates: {
-            ...selection,
-            if (startDate != null) startDate!,
-            if (endDate != null) endDate!,
+            ...config.dates,
           }.toList(),
           onSelected: _onSelected,
           style: widget.style,
@@ -139,63 +105,7 @@ class _SimpleDateRangePickerState extends State<SimpleDateRangePicker> {
   }
 
   void _onSelected(DateTime date) {
-    switch (widget.config) {
-      case SimpleDateRangePickerRange():
-        // selecting the start date again resets the selection
-        if (date == startDate) {
-          startDate = null;
-          // selecting the end date again resets the selection
-        } else if (date == endDate) {
-          endDate = null;
-          // selecting a new date when both ends of the range have been selected
-          // resets the selection with the new date as the start date
-        } else if (startDate != null && endDate != null) {
-          endDate = null;
-          startDate = date;
-          // selecting a date that lies after the end date moves the start date
-          // to the current end date and sets the end date to the newly selected
-          // date
-        } else if (endDate != null && date.isAfter(endDate!)) {
-          startDate = endDate;
-          endDate = date;
-          // selecting a date that lies before the current start date sets it as
-          // the new start date
-        } else if (startDate != null && date.isBefore(startDate!)) {
-          startDate = date;
-          // if no end date has been selected, the new date becomes the end date
-        } else if (startDate != null && endDate == null) {
-          endDate = date;
-          // if all other conditions are false, this newly selected date is the
-          // beginning of a new date range
-        } else {
-          startDate = date;
-        }
-
-        // after the selection has been made, if there is a selected start and
-        // end date, create the full range of dates
-        if (startDate != null && endDate != null) {
-          selection = _getDateRange(start: startDate!, end: endDate!);
-          // if there is only a start date, empty the range of dates
-        } else if (selection.isNotEmpty) {
-          selection = const [];
-        }
-    }
-
+    config.onSelected(date);
     setState(() {});
-  }
-
-  List<DateTime> _getDateRange({
-    required DateTime start,
-    required DateTime end,
-  }) {
-    final dates = <DateTime>[];
-    var date = start;
-
-    while (date.isBefore(end) || date.isSameDate(end)) {
-      dates.add(date);
-      date = date.add(const Duration(days: 1));
-    }
-
-    return dates;
   }
 }

--- a/lib/src/widgets/simple_date_range_picker.dart
+++ b/lib/src/widgets/simple_date_range_picker.dart
@@ -29,11 +29,22 @@ class _SimpleDateRangePickerState extends State<SimpleDateRangePicker> {
     super.initState();
 
     return switch (config) {
-      SimpleDateRangePickerRange(initialDateRange: final dateRange) => () {
-          if (dateRange != null) {
+      SimpleDateRangePickerRange(:final initialDateRange) => () {
+          if (initialDateRange != null) {
             currentMonth = DateTime(
-              dateRange.start.year,
-              dateRange.start.month,
+              initialDateRange.start.year,
+              initialDateRange.start.month,
+              1,
+            );
+          } else {
+            currentMonth = DateTime.now();
+          }
+        }(),
+      SimpleDateRangePickerSingle(:final initialDate) => () {
+          if (initialDate != null) {
+            currentMonth = DateTime(
+              initialDate.year,
+              initialDate.month,
               1,
             );
           } else {

--- a/lib/src/widgets/simple_date_range_picker.dart
+++ b/lib/src/widgets/simple_date_range_picker.dart
@@ -90,6 +90,7 @@ class _SimpleDateRangePickerState extends State<SimpleDateRangePicker> {
           }.toList(),
           onSelected: _onSelected,
           style: widget.style,
+          config: config,
         ),
       ],
     );

--- a/test/simple_date_range_picker_test.dart
+++ b/test/simple_date_range_picker_test.dart
@@ -24,7 +24,12 @@ void main() {
   testWidgets('smoke test', (widgetTester) async {
     await widgetTester.pumpWidget(
       TestWrapper(
-        child: SimpleDateRangePicker(onChanged: (dates) {}),
+        child: SimpleDateRangePicker(
+          config: SimpleDateRangePickerRange(
+            initialDateRange: null,
+            onChanged: (dates) {},
+          ),
+        ),
       ),
     );
 
@@ -35,10 +40,12 @@ void main() {
     await widgetTester.pumpWidget(
       TestWrapper(
         child: SimpleDateRangePicker(
-          onChanged: (dates) {},
-          initialDateRange: DateTimeRange(
-            start: DateTime(2023, 10, 1),
-            end: DateTime(2023, 10, 5),
+          config: SimpleDateRangePickerRange(
+            onChanged: (dates) {},
+            initialDateRange: DateTimeRange(
+              start: DateTime(2023, 10, 1),
+              end: DateTime(2023, 10, 5),
+            ),
           ),
         ),
       ),
@@ -51,10 +58,12 @@ void main() {
     await widgetTester.pumpWidget(
       TestWrapper(
         child: SimpleDateRangePicker(
-          onChanged: (dates) {},
-          initialDateRange: DateTimeRange(
-            start: DateTime(2023, 10, 1),
-            end: DateTime(2023, 10, 5),
+          config: SimpleDateRangePickerRange(
+            onChanged: (dates) {},
+            initialDateRange: DateTimeRange(
+              start: DateTime(2023, 10, 1),
+              end: DateTime(2023, 10, 5),
+            ),
           ),
         ),
       ),
@@ -70,7 +79,10 @@ void main() {
     await widgetTester.pumpWidget(
       TestWrapper(
         child: SimpleDateRangePicker(
-          onChanged: (dates) => dateRange = dates,
+          config: SimpleDateRangePickerRange(
+            initialDateRange: null,
+            onChanged: (dates) => dateRange = dates,
+          ),
         ),
       ),
     );


### PR DESCRIPTION
Update the picker with a new "config" class and child classes.

These config classes allow the user to define some of the behavior of the picker, such as whether it allows picking a date _range_ (using the `SimpleDateRangePickerRange` config class) or a **single** date (using the `SimpleDateRangePickerSingle` config class).

This also greatly improves the example to demonstrate how each type of picker works and looks.